### PR TITLE
Replace `jemalloc` with `mimalloc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,26 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.3+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +463,16 @@ name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -531,6 +521,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -883,7 +882,7 @@ dependencies = [
  "chrono",
  "html2text",
  "humantime-serde",
- "jemallocator",
+ "mimalloc",
  "pico-args",
  "reqwest",
  "rss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ exclude = ["/example", "/.github"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["mimalloc"]
+
 [dependencies]
 tokio = { version = "1.28", features = [
     "rt-multi-thread",
@@ -41,8 +44,8 @@ pico-args = "0.5"
 html2text = "0.6"
 slack-bk = "0.1"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemallocator = "0.5"
+# Optional dependencies
+mimalloc = { version = "0.1", optional = true }
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,9 @@ use tokio::{
 };
 use tracing::{error, info};
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
Replaces the default memory allocator [`jemalloc`](https://github.com/jemalloc/jemalloc) with [`mimalloc`](https://github.com/microsoft/mimalloc)