### PR TITLE
fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Process is terminated when a watcher stops with an error.
 ## v0.6.0-beta.0
 
 - Exclude jemalloc for MSVC target ~~(This should make it possible to build on Windows)~~ [fd98808](https://github.com/morphy2k/rss-forwarder/commit/fd98808d737de1e8d5e4c8e13abe9e6b5034c7f3)
-- Fixed and improved behaivor on errors.
+- Fixed and improved behavior on errors.
 - Rust updated to 1.66
 - Some internal minor improvements
 - Dependencies updated

--- a/src/sink/custom.rs
+++ b/src/sink/custom.rs
@@ -109,7 +109,7 @@ impl Sink for Custom {
         skip(self),
         fields(
             pid = self.process.id(),
-            commad = %self.command,
+            command = %self.command,
             arguments = %self.arguments.join(" "),
         ),
         level = "debug"


### PR DESCRIPTION
found via `typos --hidden --format brief`